### PR TITLE
util/hlc: add protection against clock jumps

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -87,6 +87,10 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// localStoreFutureWallTimeSuffix stores a time in the future which is
+	// guaranteed to be greater than wall time of the HLC.
+	// This is used if server.hlc.persist_wall_time is true
+	localStoreFutureWallTimeSuffix = []byte("mxtm")
 	// localStoreSuggestedCompactionSuffix stores suggested compactions to
 	// be aggregated and processed on the store.
 	localStoreSuggestedCompactionSuffix = []byte("comp")

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -75,6 +75,12 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
+// StoreFutureWallTimeKey returns the key for the storing a wall clock time
+// greater than any used by the HLC
+func StoreFutureWallTimeKey() roachpb.Key {
+	return MakeStoreKey(localStoreFutureWallTimeSuffix, nil)
+}
+
 // StoreSuggestedCompactionKey returns a store-local key for a
 // suggested compaction. It combines the specified start and end keys.
 func StoreSuggestedCompactionKey(start, end roachpb.Key) roachpb.Key {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -37,6 +37,7 @@ func TestStoreKeyEncodeDecode(t *testing.T) {
 		{key: StoreGossipKey(), expSuffix: localStoreGossipSuffix, expDetail: nil},
 		{key: StoreClusterVersionKey(), expSuffix: localStoreClusterVersionSuffix, expDetail: nil},
 		{key: StoreLastUpKey(), expSuffix: localStoreLastUpSuffix, expDetail: nil},
+		{key: StoreFutureWallTimeKey(), expSuffix: localStoreFutureWallTimeSuffix, expDetail: nil},
 		{
 			key:       StoreSuggestedCompactionKey(roachpb.Key("a"), roachpb.Key("z")),
 			expSuffix: localStoreSuggestedCompactionSuffix,

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -236,8 +236,7 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 }
 
 func (r RemoteOffset) isHealthy(ctx context.Context, maxOffset time.Duration) bool {
-	// Tolerate up to 80% of the maximum offset.
-	toleratedOffset := maxOffset * 4 / 5
+	toleratedOffset := hlc.ToleratedOffset(maxOffset)
 
 	// Offset may be negative, but Uncertainty is always positive.
 	absOffset := r.Offset

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -468,6 +468,13 @@ func (n *Node) SetDraining(drain bool) error {
 	})
 }
 
+// SetFutureWallTime sets the future wall time on all of the node's underlying stores.
+func (n *Node) SetFutureWallTime(ctx context.Context, futureWallTime int64) error {
+	return n.stores.VisitStores(func(s *storage.Store) error {
+		return s.WriteFutureWallTime(ctx, futureWallTime)
+	})
+}
+
 // initStores initializes the Stores map from ID to Store. Stores are
 // added to the local sender if already bootstrapped. A bootstrapped
 // Store has a valid ident with cluster, node and Store IDs set. If

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1691,6 +1691,72 @@ func (s *Store) ReadLastUpTimestamp(ctx context.Context) (hlc.Timestamp, error) 
 	return timestamp, nil
 }
 
+// WriteFutureWallTime records a future timestamp greater than any timestamp
+// used by the HLC.
+func (s *Store) WriteFutureWallTime(ctx context.Context, time int64) error {
+	ctx = s.AnnotateCtx(ctx)
+	return WriteFutureWallTime(ctx, s.Engine(), time)
+}
+
+// ReadFutureWallTime returns the stored future timestamp which is greater
+// than any timestamp used by the server. If this value does not exist
+// 0 is returned
+func ReadFutureWallTime(ctx context.Context, e engine.Engine) (int64, error) {
+	var timestamp hlc.Timestamp
+	ok, err := engine.MVCCGetProto(
+		ctx, e, keys.StoreFutureWallTimeKey(), hlc.Timestamp{}, true, nil, &timestamp)
+	if err != nil {
+		return 0, err
+	} else if !ok {
+		return 0, nil
+	}
+	return timestamp.WallTime, nil
+}
+
+// ReadMaxFutureWallTime returns the maximum of the stored future wall times among all
+// the engines. This value is persisted by the HLC and the it is guaranteed to be higher than
+// any timestamp used by the HLC. If this value is persisted, HLC wall clock monotonicity is
+// guaranteed across server restarts
+func ReadMaxFutureWallTime(ctx context.Context, engines []engine.Engine) (int64, error) {
+	var futureWallTime int64 = 0
+	for _, e := range engines {
+		engineFutureWallTime, err := ReadFutureWallTime(ctx, e)
+		if err != nil {
+			return 0, err
+		}
+		if engineFutureWallTime > futureWallTime {
+			futureWallTime = engineFutureWallTime
+		}
+	}
+	return futureWallTime, nil
+}
+
+// WriteFutureWallTime records a future timestamp greater than any timestamp
+// used by the HLC.
+func WriteFutureWallTime(ctx context.Context, e engine.Engine, time int64) error {
+	ts := hlc.Timestamp{WallTime: time}
+	return engine.MVCCPutProto(
+		ctx,
+		e,
+		nil,
+		keys.StoreFutureWallTimeKey(),
+		hlc.Timestamp{},
+		nil,
+		&ts,
+	)
+}
+
+// WriteFutureWallTimeToEngines records a future timestamp greater than any timestamp
+// used by the HLC to all the given engines.
+func WriteFutureWallTimeToEngines(ctx context.Context, engines []engine.Engine, time int64) error {
+	for _, e := range engines {
+		if err := WriteFutureWallTime(ctx, e, time); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
 	kvs, err := engine.Scan(
 		eng,

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -797,12 +797,17 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		// https://github.com/cockroachdb/cockroach/issues/23119
 		fatalTrigger = make(chan struct{})
 		exitFunc := l.exitFunc
+		exitCalled := make(chan struct{})
+		defer func() {
+			<-exitCalled
+		}()
 		go func() {
 			select {
 			case <-time.After(10 * time.Second):
 			case <-fatalTrigger:
 			}
 			exitFunc(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+			close(exitCalled)
 		}()
 	} else if l.traceLocation.isSet() {
 		if l.traceLocation.match(file, line) {


### PR DESCRIPTION
A cluster setting is added to panic on clock jumps. The existing
safeguard in forward clock jumps is in periodic inter-node heartbeats,
so there is a window where anomalies could occur.

This change adds forward and backward jump checks to HLC (and a background
goroutine to keep lastPhysicalTime up to date).

A cluster setting is added to periodically persist wall time to disk.
The HLC is guaranteed to not use a wall time greater than the persisted
value. When cockroach restarts, it waits for the wall time to reach the
persisted value before starting up. This guarantees monotonic wall time
across restarts

Fixes #23214

Release note (general change): Added cluster settings for HLC to be
monotonic across restarts and the server to panic on clock jumps