### PR TITLE
util/hlc: option for monotonic wall time across restarts

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -87,6 +87,10 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// localStoreFutureWallTimeSuffix stores a time in the future which is
+	// guaranteed to be greater than wall time of the HLC.
+	// This is used if server.clock.persist_wall_time is true
+	localStoreFutureWallTimeSuffix = []byte("mxtm")
 	// localStoreSuggestedCompactionSuffix stores suggested compactions to
 	// be aggregated and processed on the store.
 	localStoreSuggestedCompactionSuffix = []byte("comp")

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -75,6 +75,12 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
+// StoreFutureWallTimeKey returns the key for the storing a wall clock time
+// greater than any used by the HLC
+func StoreFutureWallTimeKey() roachpb.Key {
+	return MakeStoreKey(localStoreFutureWallTimeSuffix, nil)
+}
+
 // StoreSuggestedCompactionKey returns a store-local key for a
 // suggested compaction. It combines the specified start and end keys.
 func StoreSuggestedCompactionKey(start, end roachpb.Key) roachpb.Key {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -37,6 +37,7 @@ func TestStoreKeyEncodeDecode(t *testing.T) {
 		{key: StoreGossipKey(), expSuffix: localStoreGossipSuffix, expDetail: nil},
 		{key: StoreClusterVersionKey(), expSuffix: localStoreClusterVersionSuffix, expDetail: nil},
 		{key: StoreLastUpKey(), expSuffix: localStoreLastUpSuffix, expDetail: nil},
+		{key: StoreFutureWallTimeKey(), expSuffix: localStoreFutureWallTimeSuffix, expDetail: nil},
 		{
 			key:       StoreSuggestedCompactionKey(roachpb.Key("a"), roachpb.Key("z")),
 			expSuffix: localStoreSuggestedCompactionSuffix,

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -468,6 +468,13 @@ func (n *Node) SetDraining(drain bool) error {
 	})
 }
 
+// SetFutureWallTime sets the future wall time on all of the node's underlying stores.
+func (n *Node) SetFutureWallTime(ctx context.Context, futureWallTime int64) error {
+	return n.stores.VisitStores(func(s *storage.Store) error {
+		return s.WriteFutureWallTime(ctx, futureWallTime)
+	})
+}
+
 // initStores initializes the Stores map from ID to Store. Stores are
 // added to the local sender if already bootstrapped. A bootstrapped
 // Store has a valid ident with cluster, node and Store IDs set. If

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1725,6 +1725,72 @@ func (s *Store) ReadLastUpTimestamp(ctx context.Context) (hlc.Timestamp, error) 
 	return timestamp, nil
 }
 
+// WriteFutureWallTime records a future timestamp greater than any timestamp
+// used by the HLC.
+func (s *Store) WriteFutureWallTime(ctx context.Context, time int64) error {
+	ctx = s.AnnotateCtx(ctx)
+	return WriteFutureWallTime(ctx, s.Engine(), time)
+}
+
+// ReadFutureWallTime returns the stored future timestamp which is greater
+// than any timestamp used by the server. If this value does not exist
+// 0 is returned
+func ReadFutureWallTime(ctx context.Context, e engine.Engine) (int64, error) {
+	var timestamp hlc.Timestamp
+	ok, err := engine.MVCCGetProto(
+		ctx, e, keys.StoreFutureWallTimeKey(), hlc.Timestamp{}, true, nil, &timestamp)
+	if err != nil {
+		return 0, err
+	} else if !ok {
+		return 0, nil
+	}
+	return timestamp.WallTime, nil
+}
+
+// ReadMaxFutureWallTime returns the maximum of the stored future wall times among all
+// the engines. This value is persisted by the HLC and the it is guaranteed to be higher than
+// any timestamp used by the HLC. If this value is persisted, HLC wall clock monotonicity is
+// guaranteed across server restarts
+func ReadMaxFutureWallTime(ctx context.Context, engines []engine.Engine) (int64, error) {
+	var futureWallTime int64
+	for _, e := range engines {
+		engineFutureWallTime, err := ReadFutureWallTime(ctx, e)
+		if err != nil {
+			return 0, err
+		}
+		if engineFutureWallTime > futureWallTime {
+			futureWallTime = engineFutureWallTime
+		}
+	}
+	return futureWallTime, nil
+}
+
+// WriteFutureWallTime records a future timestamp greater than any timestamp
+// used by the HLC.
+func WriteFutureWallTime(ctx context.Context, e engine.Engine, time int64) error {
+	ts := hlc.Timestamp{WallTime: time}
+	return engine.MVCCPutProto(
+		ctx,
+		e,
+		nil,
+		keys.StoreFutureWallTimeKey(),
+		hlc.Timestamp{},
+		nil,
+		&ts,
+	)
+}
+
+// WriteFutureWallTimeToEngines records a future timestamp greater than any timestamp
+// used by the HLC to all the given engines.
+func WriteFutureWallTimeToEngines(ctx context.Context, engines []engine.Engine, time int64) error {
+	for _, e := range engines {
+		if err := WriteFutureWallTime(ctx, e, time); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
 	kvs, err := engine.Scan(
 		eng,

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -30,6 +30,24 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// The following constants are used if server.clock.persist_future_wall_time
+	// is true
+
+	// persistFutureWallTimeInterval is the interval used for persisting the
+	// future wall time
+	persistFutureWallTimeInterval = 400 * time.Millisecond
+	// persistFutureWallTimeDelta is the delta used to compute the future wall
+	// time. This should be greater than persistFutureWallTimeInterval
+	persistFutureWallTimeDelta = int64(15 * time.Second)
+
+	// maxSleepToEnsureMonotonicity is the max duration to sleep while waiting
+	// for wall time to catch up to the persisted future wall time. The physical
+	// clock could have jumped so the delta between physical time and persisted
+	// future wall time is recomputed periodically
+	maxSleepToEnsureMonotonicity = 10 * time.Second
+)
+
 // TODO(Tobias): Figure out if it would make sense to save some
 // history of the physical clock and react if it jumps backwards
 // repeatedly. This is expected during NTP updates, but may
@@ -78,6 +96,15 @@ type Clock struct {
 		// isMonitoringClockJumps is a flag to ensure that only one jump monitoring
 		// goroutine is running per clock
 		isMonitoringClockJumps bool
+
+		// futureWallTime is latest future wall time successfully persisted.
+		// The wall time used by the HLC will always be lesser than this timestamp.
+		// If this is set to 0, this validation is skipped
+		futureWallTime int64
+
+		// isPersistingFutureWallTime is a flag to ensure that only one persisting
+		// goroutine is running per clock
+		isPersistingFutureWallTime bool
 	}
 }
 
@@ -189,6 +216,124 @@ func (c *Clock) StartMonitoringForwardClockJumps(
 	return nil
 }
 
+// wallTimeToPersist returns the wall time offset by persistFutureWallTimeDelta
+func (c *Clock) wallTimeToPersist() int64 {
+	return c.Now().WallTime + persistFutureWallTimeDelta
+}
+
+// EnsureInitialWallTimeMonotonicity sleeps till the wall time reaches
+// prevWallTime. prevWallTime > 0 implies we need to guarantee wall time
+// monotonicity across server restarts. prevWallTime is the last successfully
+// persisted timestamp greater then any wall time used by the server.
+//
+// persistWallTimeFn is used to persist the future wall time, and should return
+// an error if the persist fails.
+func (c *Clock) EnsureInitialWallTimeMonotonicity(
+	ctx context.Context,
+	prevWallTime int64,
+	persistWallTimeFn func(int64) error,
+	sleepFn func(d time.Duration),
+) error {
+	if prevWallTime == 0 {
+		return nil
+	}
+
+	for {
+		currentWallTime := c.Now().WallTime
+		sleepTime := time.Duration(prevWallTime-currentWallTime) + 1
+		if sleepTime <= 0 {
+			break
+		}
+		if sleepTime > maxSleepToEnsureMonotonicity {
+			sleepTime = maxSleepToEnsureMonotonicity
+		}
+
+		log.Infof(
+			ctx,
+			"Sleeping for %v to for wall time %v to catch up to %v to ensure monotonicity",
+			sleepTime,
+			currentWallTime,
+			prevWallTime,
+		)
+		sleepFn(sleepTime)
+	}
+
+	if prevWallTime > 0 {
+		// A non zero prevWallTime signifies that the feature to persist future
+		// wall times is enabled. Persist a new future wall time to continue
+		// guaranteeing monotonicity
+		return c.updateFutureWallTime(persistWallTimeFn, c.wallTimeToPersist())
+	}
+	return nil
+}
+
+// StartPersistingFutureWallTime starts a goroutine to persist a future wall time.
+// The values pushed in persistFutureWallTimeCh specify whether the future
+// timestamp should be persisted.
+//
+// persistWallTimeFn is used to persist the future wall time, and should return
+// an error if the persist fails
+//
+// tickerFn is used to create a new ticker
+//
+// tickCallback is called whenever maxClockJumpCh or a ticker tick is processed
+func (c *Clock) StartPersistingFutureWallTime(
+	persistFutureWallTimeCh <-chan bool,
+	persistWallTimeFn func(int64) error,
+	tickerFn func(d time.Duration) *time.Ticker,
+	tickCallback func(),
+) error {
+	alreadyPersisting := c.setPersistingFutureWallTime()
+	if alreadyPersisting {
+		return errors.New("future wall time is already being persisted")
+	}
+
+	go func() {
+		ticker := tickerFn(persistFutureWallTimeInterval)
+		ticker.Stop()
+
+		for {
+			select {
+			case persistFutureWallTime, ok := <-persistFutureWallTimeCh:
+				ticker.Stop()
+				if !ok {
+					return
+				}
+
+				if persistFutureWallTime {
+					ticker = tickerFn(persistFutureWallTimeInterval)
+				} else {
+					persistWallTime := int64(0)
+					if err := c.updateFutureWallTime(persistWallTimeFn, persistWallTime); err != nil {
+						log.Fatalf(
+							context.Background(),
+							"error persisting future wall time of %d: %v",
+							persistWallTime,
+							err,
+						)
+					}
+				}
+
+			case <-ticker.C:
+				futureWallTime := c.wallTimeToPersist()
+				if err := c.updateFutureWallTime(persistWallTimeFn, futureWallTime); err != nil {
+					log.Fatalf(
+						context.Background(),
+						"error persisting future wall time of %d: %v",
+						futureWallTime,
+						err,
+					)
+				}
+			}
+
+			if tickCallback != nil {
+				tickCallback()
+			}
+		}
+	}()
+	return nil
+}
+
 // MaxOffset returns the maximal clock offset to any node in the cluster.
 //
 // A value of 0 means offset checking is disabled.
@@ -206,6 +351,17 @@ func (c *Clock) getPhysicalClockLocked() int64 {
 		if interval > int64(c.maxOffset/10) {
 			c.mu.monotonicityErrorsCount++
 			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(-interval)/1e9)
+		}
+
+		// Physical time should not cross the persisted future wall time (if futureWallTime is set)
+		if c.mu.futureWallTime != 0 && newTime > c.mu.futureWallTime {
+			log.Fatalf(
+				context.TODO(),
+				"Cluster setting server.clock.persist_future_wall_time does not allow physical time "+
+					"%d to be greater than persisted wall time %d.",
+				c.mu.lastPhysicalTime,
+				c.mu.futureWallTime,
+			)
 		}
 
 		if c.mu.maxForwardClockJump > 0 {
@@ -350,4 +506,35 @@ func (c *Clock) setMonitoringClockJump() bool {
 	isMonitoring := c.mu.isMonitoringClockJumps
 	c.mu.isMonitoringClockJumps = true
 	return isMonitoring
+}
+
+// updateFutureWallTime persists the future wall time and updates the in memory value
+// if the persist succeeds
+func (c *Clock) updateFutureWallTime(persistFn func(int64) error, futureWallTime int64) error {
+	if err := persistFn(futureWallTime); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.futureWallTime = futureWallTime
+	return nil
+}
+
+// futureWallTime returns the in memory value of future wall time
+func (c *Clock) futureWallTime() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.futureWallTime
+}
+
+// setPersistingFutureWallTime atomically sets isMonitoringClockJumps to true
+// and returns the old value. This is used to ensure that only one persisting
+// goroutine is launched
+func (c *Clock) setPersistingFutureWallTime() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	isPersisting := c.mu.isPersistingFutureWallTime
+	c.mu.isPersistingFutureWallTime = true
+	return isPersisting
 }


### PR DESCRIPTION
A cluster setting is added to periodically persist wall time to RocksDB.
The HLC is guaranteed to not use a wall time greater than the persisted
value. When cockroach restarts, it waits for the wall time to reach the
persisted value before starting up. This guarantees monotonic wall time
across restarts.

Release note (general change): Added cluster settings for HLC to be
monotonic across restart